### PR TITLE
fix(project-config): add missing imports for WordPress detail panels

### DIFF
--- a/src/core/lib/project-config.ts
+++ b/src/core/lib/project-config.ts
@@ -27,6 +27,8 @@ import { StaticShellPanel } from "@/features/projects/components/detail/static/S
 import { WordPressOverviewPanel } from "@/features/projects/components/detail/wordpress/WordPressOverviewPanel";
 import { WordPressPluginsPanel } from "@/features/projects/components/detail/wordpress/WordPressPluginsPanel";
 import { WordPressThemesPanel } from "@/features/projects/components/detail/wordpress/WordPressThemesPanel";
+import { WordPressDatabasePanel } from "@/features/projects/components/detail/wordpress/WordPressDatabasePanel";
+import { WordPressLogsPanel } from "@/features/projects/components/detail/wordpress/WordPressLogsPanel";
 import type { PanelConfig, ProjectType, TabConfig } from "@/features/projects/types";
 
 interface ProjectConfig {


### PR DESCRIPTION
## Summary

Fixed missing imports for the WordPress detail panel components in `project-config.ts`.

### Changes

* Added the missing `WordPressDatabasePanel` import.
* Added the missing `WordPressLogsPanel` import.
* Resolved undefined component references in `PROJECT_DETAIL_CONFIG`.
* Fixed the runtime error caused by missing panel imports.

### Result

The WordPress project detail configuration now correctly resolves all panel components, and the application loads the WordPress detail view without import-related errors.
